### PR TITLE
Fix error handler on http.request error

### DIFF
--- a/client.js
+++ b/client.js
@@ -67,6 +67,9 @@ WemoClient.request = function(options, data, cb) {
       cb(err);
     });
   });
+  req.on('error', function(err) {
+    cb(err);
+  });
   if (data) {
     req.write(data);
   }


### PR DESCRIPTION
I'm using @rudders Wemo platform for Homebridge, and my server kept crashing with the following error on my WeMo NetCam device:
```
events.js:85
      throw er; // Unhandled 'error' event
            ^
Error: connect EHOSTUNREACH
    at exports._errnoException (util.js:746:11)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1010:19)
```

I found that the `error` event handler added within the callback was not being called, adding the additional callback directly on the http.request object resolves this issue. I'm not sure if you still need the one inside the callback...but it should be easy enough to test.