### PR TITLE
More error handling on http.requests.

### DIFF
--- a/client.js
+++ b/client.js
@@ -242,6 +242,9 @@ WemoClient.prototype._subscribe = function(serviceType) {
       setTimeout(this._subscribe.bind(this), 120 * 1000, serviceType);
     }
   }.bind(this));
+  req.on('error', function(err) {
+    cb(err);
+  });
   req.end();
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wemo-client",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "JavaScript client library for controlling and subscribing to Wemo Devices",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
This change catches request errors which were causing instability for a homebridge-platform-wemo user and is probably just good to do anyway networks being what they are and wemos being what they are.