### PR TITLE
Error handling and Wemo Bulb Group Enhancements

### DIFF
--- a/client.js
+++ b/client.js
@@ -251,13 +251,9 @@ WemoClient.prototype._subscribe = function(serviceType) {
     });
     
   req.on('error', function(err) {
-    if (err.code === "ECONNRESET") {
-        console.log("ECONNRESET occured, we'll ignore it for now!");
-        //specific error treatment
-    } else {
-        console.log("Some error (%s) occured, we'll ignore", err.code);
-        }
+    console.log("Error (%s) occured subscribing to %s, we'll ignore", err.code, this.friendlyName );
     });
+    
   req.end();
 };
 

--- a/client.js
+++ b/client.js
@@ -266,7 +266,7 @@ WemoClient.prototype._subscribe = function(serviceType) {
     console.log("HTTP Error (%s) occurred (re)subscribing to Wemo Device (%s - %s:%s), retrying.", 
         err.code, wemo.device.friendlyName, wemo.device.host, wemo.device.port, wemo.UDN);
     if (err.code === 'ECONNREFUSED') { // try the alternate port that wemo tends to use.
-        ( wemo.port === '49154' ) ? wemo.port-- : wemo.port++ ;
+        ( wemo.port === '49154' ) ? wemo.port = '49153' : wemo.port = '49154' ;
         console.log('Trying port: %s', wemo.port);
         timeout = 1; // may as well try the new port sooner than later
     }

--- a/client.js
+++ b/client.js
@@ -242,6 +242,9 @@ WemoClient.prototype._subscribe = function(serviceType) {
       setTimeout(this._subscribe.bind(this), 120 * 1000, serviceType);
     }
   }.bind(this));
+  req.on('error', function(err) {
+    cb(err);
+  });
   req.end();
 };
 

--- a/client.js
+++ b/client.js
@@ -251,7 +251,7 @@ WemoClient.prototype._subscribe = function(serviceType) {
     });
     
   req.on('error', function(err) {
-    console.log("Error (%s) occured subscribing to %s, we'll ignore", err.code, this.friendlyName );
+    console.log("Error (%s) occured subscribing to a wemo, we'll ignore. Device: ", err.code, this );
     });
     
   req.end();

--- a/client.js
+++ b/client.js
@@ -251,7 +251,8 @@ WemoClient.prototype._subscribe = function(serviceType) {
     });
     
   req.on('error', function(err) {
-    console.log("Error (%s) occured subscribing to a wemo, we'll ignore. Device: ", err.code, this );
+    var re = /quick\s(brown).+?(jumps)/ig;
+    console.log("Error (%s) occured subscribing to a wemo, we'll ignore. Device: ", err.code, this.exec(re));
     });
     
   req.end();

--- a/client.js
+++ b/client.js
@@ -66,12 +66,16 @@ WemoClient.request = function(options, data, cb) {
       xml2js.parseString(body, { explicitArray: false }, cb);
     });
     res.on('error', function(err) {
-      console.log("Error on http.request.res:", err)
+      debug("Error on http.request.res:", err)
       cb(err);
     });
   });
+  req.setTimeout( 3000, function () {  // 3 seconds to respond so we're inside the homekit wait
+      req.abort();
+      debug("Error on http.request.req: Timed out!")}
+      ); 
   req.on('error', function(err) {
-      console.log("Error on http.request.req:", err)
+    debug("Error on http.request.req:", err);
     cb(err);
   });
   if (data) {

--- a/client.js
+++ b/client.js
@@ -254,8 +254,9 @@ WemoClient.prototype._subscribe = function(serviceType) {
     if (err.code === "ECONNRESET") {
         console.log("ECONNRESET occured, we'll ignore it for now!");
         //specific error treatment
-    }
+    } else {
         console.log("Some error (%s) occured, we'll ignore", err.code);
+        }
     });
   req.end();
 };

--- a/client.js
+++ b/client.js
@@ -251,8 +251,7 @@ WemoClient.prototype._subscribe = function(serviceType) {
     });
     
   req.on('error', function(err) {
-    var re = /(\d+\.\d+\.\d+\.\d+):(\d+)/;
-    console.log("Error (%s) occured subscribing to a wemo, we'll ignore. Device: ", err.code, re.exec(this));
+    console.log("Error (%s) occured subscribing to a wemo, we'll ignore. HTTP Request Device Data: ", err.code, this.connection._pendingData);
     });
     
   req.end();

--- a/client.js
+++ b/client.js
@@ -252,10 +252,10 @@ WemoClient.prototype._subscribe = function(serviceType) {
     
   req.on('error', function(err) {
     if (err.code === "ECONNRESET") {
-        this.log("ECONNRESET occured, we'll ignore it for now!");
+        console.log("ECONNRESET occured, we'll ignore it for now!");
         //specific error treatment
     }
-        this.log("Some error (%s) occured, we'll ignore", err.code);
+        console.log("Some error (%s) occured, we'll ignore", err.code);
     });
   req.end();
 };

--- a/client.js
+++ b/client.js
@@ -113,13 +113,13 @@ WemoClient.prototype.getEndDevices = function(cb) {
   var parseDeviceInfo = function(data) {
     var device = {};
 
-    if (data.GroupInfo) {
+    if (data.GroupID) {
       // treat device group as it was a single device
-      device.friendlyName = data.GroupInfo[0].GroupName[0];
-      device.deviceId = data.GroupInfo[0].GroupID[0];
+      device.friendlyName = data.GroupName[0];
+      device.deviceId = data.GroupID[0];
       device.capabilities = mapCapabilities(
-        data.GroupInfo[0].GroupCapabilityIDs[0],
-        data.GroupInfo[0].GroupCapabilityValues[0]
+        data.GroupCapabilityIDs[0],
+        data.GroupCapabilityValues[0]
       );
     } else {
       // single device
@@ -152,8 +152,9 @@ WemoClient.prototype.getEndDevices = function(cb) {
       if (deviceInfos) {
         Array.prototype.push.apply(endDevices, deviceInfos.map(parseDeviceInfo));
       }
-      var groupInfos = result.DeviceLists.DeviceList[0].GroupInfos;
-      if (groupInfos) {
+      if(result.DeviceLists.DeviceList[0].GroupInfos) {
+          var groupInfos = result.DeviceLists.DeviceList[0].GroupInfos[0].GroupInfo;
+//       if (groupInfos) {
         Array.prototype.push.apply(endDevices, groupInfos.map(parseDeviceInfo));
       }
       cb(null, endDevices);
@@ -163,7 +164,6 @@ WemoClient.prototype.getEndDevices = function(cb) {
   var body = '<DevUDN>%s</DevUDN><ReqListType>PAIRED_LIST</ReqListType>';
   this.soapAction('urn:Belkin:service:bridge:1', 'GetEndDevices', util.format(body, this.UDN), parseResponse);
 };
-
 WemoClient.prototype.setDeviceStatus = function(deviceId, capability, value, cb) {
   var isGroupAction = (deviceId.length === 10) ? 'YES' : 'NO';
   var body = [

--- a/client.js
+++ b/client.js
@@ -144,6 +144,7 @@ WemoClient.prototype.getEndDevices = function(cb) {
 
   var parseResponse = function(err, data) {
     if (err) return cb(err);
+    debug('endDevices raw data',data);
     var endDevices = [];
     xml2js.parseString(data.DeviceLists, function(err, result) {
       if (err) return cb(err);

--- a/client.js
+++ b/client.js
@@ -252,7 +252,7 @@ WemoClient.prototype._subscribe = function(serviceType) {
     
   req.on('error', function(err) {
     var re = /(\d+\.\d+\.\d+\.\d+):(\d+)/;
-    console.log("Error (%s) occured subscribing to a wemo, we'll ignore. Device: ", err.code, this.exec(re));
+    console.log("Error (%s) occured subscribing to a wemo, we'll ignore. Device: ", err.code, re.exec(this));
     });
     
   req.end();

--- a/client.js
+++ b/client.js
@@ -251,7 +251,7 @@ WemoClient.prototype._subscribe = function(serviceType) {
     });
     
   req.on('error', function(err) {
-    var re = /quick\s(brown).+?(jumps)/ig;
+    var re = /(\d+\.\d+\.\d+\.\d+):(\d+)/;
     console.log("Error (%s) occured subscribing to a wemo, we'll ignore. Device: ", err.code, this.exec(re));
     });
     

--- a/client.js
+++ b/client.js
@@ -248,7 +248,7 @@ WemoClient.prototype._subscribe = function(serviceType) {
   }.bind(this));
   
   req.on('error', function(err) {
-    console.log("HTTP Error (%s) occurred resubscribing to Wemo Device (%s - %s:%s), waiting and retrying in 5s.", err.code, wemo.device.friendlyName, wemo.device.host, wemo.device.port);
+    console.log("HTTP Error (%s) occurred resubscribing to Wemo Device (%s - %s:%s), waiting and retrying in 5s.", err.code, wemo.device.friendlyName, wemo.device.host, wemo.device.port, wemo.UDN);
     setTimeout(this._subscribe.bind(this), 5 * 1000, serviceType);
     }.bind(this));
     

--- a/client.js
+++ b/client.js
@@ -245,7 +245,7 @@ WemoClient.prototype._subscribe = function(serviceType) {
     }
   }.bind(this));
   req.on('error', function(err) {
-    debug('Failure on subscription request - Device: %s, Service: %s, Error:', self.UDN, serviceType,err);
+    debug('Failure on subscription request IGNORED - Device: %s, Service: %s, Error:', self.UDN, serviceType, err);
   });
   req.end();
 };

--- a/client.js
+++ b/client.js
@@ -251,7 +251,7 @@ WemoClient.prototype._subscribe = function(serviceType) {
     });
     
   req.on('error', function(err) {
-    console.log("Error (%s) occured subscribing to a wemo, we'll ignore. HTTP Request Device Data: ", err.code, this.connection._pendingData);
+    console.log("Error (%s) occured subscribing to a wemo, we'll ignore. HTTP Request Device Data:\n", err.code, this.connection._pendingData);
     });
     
   req.end();

--- a/client.js
+++ b/client.js
@@ -235,7 +235,9 @@ WemoClient.prototype._subscribe = function(serviceType) {
     debug('Renewing subscription - Device: %s, Service: %s', this.UDN, serviceType);
     options.headers.SID = this.subscriptions[serviceType];
   }
-
+  
+  var self=this;
+  
   var req = http.request(options, function(res) {
     if (res.headers.sid) {
       this.subscriptions[serviceType] = res.headers.sid;
@@ -243,7 +245,7 @@ WemoClient.prototype._subscribe = function(serviceType) {
     }
   }.bind(this));
   req.on('error', function(err) {
-    cb(err);
+    debug('Failure on subscription request - Device: %s, Service: %s, Error:', self.UDN, serviceType,err);
   });
   req.end();
 };

--- a/index.js
+++ b/index.js
@@ -20,12 +20,6 @@ Wemo.DEVICE_TYPE = {
   LightSwitch: 'urn:Belkin:device:lightswitch:1'
 };
 
-Wemo.ERROR = {
-    Timeout: 'ETIMEDOUT',
-    Refused: 'ECONNREFUSED',
-    Down:    'EHOSTDOWN'
-}
-
 Wemo.prototype.load = function(setupUrl, cb) {
   var self = this;
   var location = url.parse(setupUrl);
@@ -67,7 +61,9 @@ Wemo.prototype.discover = function(cb) {
 Wemo.prototype._listen = function() {
   this._server = http.createServer(this._handleRequest.bind(this));
   this._server.listen(0, function(err) {
-    if (err) throw err;
+    if (err) {
+      throw err;
+    }
   });
 };
 
@@ -115,11 +111,11 @@ Wemo.prototype.getCallbackURL = function() {
   return this._callbackURL;
 };
 
-Wemo.prototype.client = function(device) {
+Wemo.prototype.client = function(device, log) {
   if (this._clients[device.UDN]) {
     return this._clients[device.UDN];
   }
 
-  var client = this._clients[device.UDN] = new WemoClient(device);
+  var client = this._clients[device.UDN] = new WemoClient(device, log);
   return client;
 };

--- a/index.js
+++ b/index.js
@@ -20,6 +20,12 @@ Wemo.DEVICE_TYPE = {
   LightSwitch: 'urn:Belkin:device:lightswitch:1'
 };
 
+Wemo.ERROR = {
+    Timeout: 'ETIMEDOUT',
+    Refused: 'ECONNREFUSED',
+    Down:    'EHOSTDOWN'
+}
+
 Wemo.prototype.load = function(setupUrl, cb) {
   var self = this;
   var location = url.parse(setupUrl);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wemo-client",
-  "version": "0.6.4a",
+  "version": "0.6.4b",
   "description": "JavaScript client library for controlling and subscribing to Wemo Devices",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wemo-client",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "JavaScript client library for controlling and subscribing to Wemo Devices",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wemo-client",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "JavaScript client library for controlling and subscribing to Wemo Devices",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wemo-client",
-  "version": "0.6.6",
+  "version": "0.6.2",
   "description": "JavaScript client library for controlling and subscribing to Wemo Devices",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "test": "istanbul test _mocha",
     "test-cov": "istanbul cover _mocha",
     "test-e2e": "mocha ./test-e2e",
+    "lint": "eslint *.js",
+    "prepush": "npm run lint && npm test",
+    "postmerge": "npm install",
     "preversion": "npm test",
     "postversion": "git push && git push --tags"
   },
@@ -33,6 +36,8 @@
   },
   "devDependencies": {
     "codeclimate-test-reporter": "^0.1.1",
+    "eslint": "^1.10.3",
+    "husky": "^0.10.2",
     "istanbul": "~0.3.17",
     "mitm": "~1.1.0",
     "mocha": "~2.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wemo-client",
-  "version": "0.6.4c",
+  "version": "0.6.5",
   "description": "JavaScript client library for controlling and subscribing to Wemo Devices",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wemo-client",
-  "version": "0.6.4",
+  "version": "0.6.4a",
   "description": "JavaScript client library for controlling and subscribing to Wemo Devices",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wemo-client",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "JavaScript client library for controlling and subscribing to Wemo Devices",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wemo-client",
-  "version": "0.6.4b",
+  "version": "0.6.4c",
   "description": "JavaScript client library for controlling and subscribing to Wemo Devices",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Hi Timon,

Lots of changes here and you'll see I struggled to get it working correctly. 3 things to look at.
1. Updated bulb groups to work - it previously only returned the first group, not all of them.
2. Timeout on http.request set to 3 seconds so that homekit didn’t get bored of waiting for a response - this is clearly homekit biased but probably good practice - considered making it an optional parameter on the calls.
3. Recovery from re-subscription to callbacks - I've tested this a lot and it seems to recover from everything I can throw at it - including killing the router for a minute or two and restarting.

Adrian 