### PR TITLE
Remove second call to discover

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -22,8 +22,3 @@ function foundDevice(deviceInfo) {
 
 // Inital discovery
 wemo.discover(foundDevice);
-
-// Repeat discovery as some devices may appear late
-setInterval(function() {
-  wemo.discover(foundDevice);
-}, 15000);


### PR DESCRIPTION
Don't think this second call to the discover method is necessary.. as I understand it discover takes a callback as a param and that callback is called whenever a new device is discovered. If that's the case you shouldn't call discover twice - it makes this example look like discover ends and isn't continuous