### PR TITLE
Update ssdp and allow specification of bind ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,23 @@ wemo.discover(function(deviceInfo) {
 
 ### Wemo
 
+#### new Wemo([opts])
+
+Create the Wemo instance. An optional object containing options can be specified. Available options include `port` which will provide a port to bind to for listening to UPnP events (the default is to listen on any available randomly selected port.) Discovery options for `node-ssdp` can also be specified as `discover_opts`.
+
+Example of options:
+
+```
+{
+  port: 1234,
+  discover_opts: {
+    unicastBindPort: 1235
+  }
+}
+```
+
+* **Object** *options* Options
+
 #### DEVICE_TYPE
 
 Static map of supported models and device types.

--- a/index.js
+++ b/index.js
@@ -6,10 +6,13 @@ var debug = require('debug')('wemo-client');
 
 var WemoClient = require('./client');
 
-var Wemo = module.exports = function() {
+var Wemo = module.exports = function(opts) {
+  opts = opts || {};
+  this._port = opts.port || 0;
+
   this._clients = {};
   this._listen();
-  this._ssdpClient = new SSDPClient();
+  this._ssdpClient = new SSDPClient(opts.discover_opts || {});
 };
 
 Wemo.DEVICE_TYPE = {
@@ -62,7 +65,7 @@ Wemo.prototype.discover = function(cb) {
 
 Wemo.prototype._listen = function() {
   this._server = http.createServer(this._handleRequest.bind(this));
-  this._server.listen(0, function(err) {
+  this._server.listen(this._port, function(err) {
     if (err) {
       throw err;
     }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "debug": "~2.2.0",
     "entities": "^1.1.1",
-    "node-ssdp": "~2.7.0",
+    "node-ssdp": "~2.8.0",
     "xml2js": "~0.4.16",
     "xmlbuilder": "^8.2.2"
   },


### PR DESCRIPTION
I did a PR into node-ssdp to allow specifying which port to bind to for discovery as I need to be able to run these libraries behind a firewall as the default 0 picks a random available port.

This PR adds ability to specify the ports to wemo-client to use for event listening, and also for discovery.

Thanks!