### PR TITLE
Ignore invalid responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ Wemo.prototype.load = function(setupUrl, cb) {
     path: location.path,
     method: 'GET'
   }, function(err, json) {
-    if (!err && json) {
+    if (!err && json && json.root) {
       var device = json.root.device;
       device.host = location.hostname;
       device.port = location.port;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wemo-client",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Client library for interacting with Belkin Wemo devices",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
I was getting some errors discovery devices. Found a device that was responding with unexpected JSON syntax (see below). As this is not a Belkin device just going to ignore rather than add additional handling.

```
{
    "n1:root": {
        "$": {
            "xmlns:n1": "urn:schemas-upnp-org:device-1-0"
        },
        "specVersion": {
            "major": "1",
            "minor": "0"
        },
        "device": {
            "deviceType": "urn:roku-com:device:player:1-0",
            "friendlyName": "Mac mini",
            "manufacturer": "Roku",
            "manufacturerURL": "http://www.roku.com",
            "modelDescription": "Roku Streaming Player Network Media",
            "modelName": "Roku 3",
            "modelNumber": "4200X",
            "modelURL": "http://www.roku.com",
            "serialNumber": "12345678900",
            "UDN": "uuid:43a4d300-59b7-4ef7-b75a-2d9e24301688",
            "serviceList": {
                "service": {
                    "serviceType": "urn:roku-com:service:ecp:1",
                    "serviceId": "urn:roku-com:serviceId:ecp1-0",
                    "controlURL": "",
                    "eventSubURL": "",
                    "SCPDURL": "ecp_SCPD.xml"
                }
            }
        }
    }
}
```