### PR TITLE
Add additional check for json.root to prevent crashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ Wemo.prototype.load = function(setupUrl, cb) {
     path: location.path,
     method: 'GET'
   }, function(err, json) {
-    if (!err && json) {
+    if (!err && json && json.root) {
       var device = json.root.device;
       device.host = location.hostname;
       device.port = location.port;


### PR DESCRIPTION
When I'm running Plex on my network, I found that the `homebridge-platform-wemo` plugin for Homebridge was crashing with the following...

```
TypeError: Cannot read property 'device' of undefined
    at /usr/local/lib/node_modules/homebridge-platform-wemo/node_modules/wemo-client/index.js:39:29
    at Parser.<anonymous> (/usr/local/lib/node_modules/homebridge-platform-wemo/node_modules/xml2js/lib/xml2js.js:489:18)
    at emitOne (events.js:96:13)
    at Parser.emit (events.js:188:7)
    at Object.onclosetag (/usr/local/lib/node_modules/homebridge-platform-wemo/node_modules/xml2js/lib/xml2js.js:447:26)
    at emit (/usr/local/lib/node_modules/homebridge-platform-wemo/node_modules/sax/lib/sax.js:640:35)
    at emitNode (/usr/local/lib/node_modules/homebridge-platform-wemo/node_modules/sax/lib/sax.js:645:5)
    at closeTag (/usr/local/lib/node_modules/homebridge-platform-wemo/node_modules/sax/lib/sax.js:905:7)
    at Object.write (/usr/local/lib/node_modules/homebridge-platform-wemo/node_modules/sax/lib/sax.js:1449:13)
    at Parser.exports.Parser.Parser.parseString (/usr/local/lib/node_modules/homebridge-platform-wemo/node_modules/xml2js/lib/xml2js.js:508:31)
    at Parser.parseString (/usr/local/lib/node_modules/homebridge-platform-wemo/node_modules/xml2js/lib/xml2js.js:7:59)
    at Object.exports.parseString (/usr/local/lib/node_modules/homebridge-platform-wemo/node_modules/xml2js/lib/xml2js.js:540:19)
    at IncomingMessage.<anonymous> (/usr/local/lib/node_modules/homebridge-platform-wemo/node_modules/wemo-client/client.js:67:16)
    at emitNone (events.js:91:20)
    at IncomingMessage.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:934:12)
```

When I inspected the `json` variable, I found that it had a namespace attached to the root node...
```javascript
{ 'n1:root': 
   { '$': { 'xmlns:n1': 'urn:schemas-upnp-org:device-1-0' },
     specVersion: { major: '1', minor: '0' },
     device: 
      { deviceType: 'urn:roku-com:device:player:1-0',
        friendlyName: 'Office',
        manufacturer: 'Roku',
        manufacturerURL: 'http://www.roku.com',
        modelDescription: 'Roku Streaming Player Network Media',
        modelName: 'Roku 3',
        modelNumber: '4200X',
        modelURL: 'http://www.roku.com',
        serialNumber: '12345678900',
        UDN: 'uuid:800221eb-76bd-4a60-82ce-77aacd1e138d',
        serviceList: [Object] } } }
```

Adding this additional check will prevent from crashing in this situation.
