### PR TITLE
Added callback if an error occurs during Wemo.load

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ The callback will only be called for newly found devices (those that have not be
 
 #### load(setupUrl, cb)
 
-Allows to skip discovery if the `setupUrl` of a Wemo is already known. A `deviceInfo` will be passed to `cb` that can be used to get a client for the device found.
+Allows to skip discovery if the `setupUrl` of a Wemo is already known. A `deviceInfo` will be passed to `cb` that can be used to get a client for the device found. The `err` field will be non-null in the event of an error.
 
 * **String** *setupUrl* Must point to setup.xml of the requested device (`http://device_ip:device_port/setup.xml`).
-* **Callback** *cb*
+* **Callback** *cb* cb(err, deviceInfo)
 
 #### client(deviceInfo)
 

--- a/index.js
+++ b/index.js
@@ -48,6 +48,11 @@ Wemo.prototype.load = function(setupUrl, cb) {
           cb.call(self, device);
         }
       }
+    } else {
+      debug('Error occurred connecting to device at %s', location);
+      if (cb) {
+        cb.call(self, null, err);
+      }
     }
   });
 };

--- a/index.js
+++ b/index.js
@@ -45,13 +45,13 @@ Wemo.prototype.load = function(setupUrl, cb) {
       if (!self._clients[device.UDN] || self._clients[device.UDN].error) {
         debug('Found device: %j', json);
         if (cb) {
-          cb.call(self, device);
+          cb.call(self, err, device);
         }
       }
     } else {
       debug('Error occurred connecting to device at %s', location);
       if (cb) {
-        cb.call(self, null, err);
+        cb.call(self, err, null);
       }
     }
   });

--- a/test/index.js
+++ b/test/index.js
@@ -38,7 +38,7 @@ describe('Wemo', function() {
     req.end();
   });
 
-  describe('#load(setupUrl, cb)', function() {
+  describe('#load(setupUrl, cb, err)', function() {
     it('must load a device', function(done) {
       var wemo = new Wemo();
       var mitm = Mitm();
@@ -55,6 +55,23 @@ describe('Wemo', function() {
         done();
       });
 
+    });
+
+    it('must error if no connection can be established', function(done) {
+      var wemo = new Wemo();
+      var mitm = Mitm();
+      mitm.on('request', function(req, res) {
+        req.url.must.be('/setup.xml');
+        res.statusCode = 404;
+        res.write('Failed to connect');
+        res.end();
+        mitm.disable();
+      });
+
+      wemo.load('http://127.0.0.2/setup.xml', function(device, err) {
+        demand(err).not.be.undefined();
+        done();
+      });
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -50,8 +50,9 @@ describe('Wemo', function() {
         mitm.disable();
       });
 
-      wemo.load('http://127.0.0.2/setup.xml', function(device) {
-        deviceInfo.serialNumber.must.be('000000000000B');
+      wemo.load('http://127.0.0.2/setup.xml', function(err, device) {
+        demand(err).must.be.falsy();
+        device.serialNumber.must.be('000000000000B');
         done();
       });
 
@@ -68,7 +69,7 @@ describe('Wemo', function() {
         mitm.disable();
       });
 
-      wemo.load('http://127.0.0.2/setup.xml', function(device, err) {
+      wemo.load('http://127.0.0.2/setup.xml', function(err) {
         demand(err).not.be.undefined();
         done();
       });


### PR DESCRIPTION
Errors were being dropped from the internal callback which means calling code can't see them. I've added an optional extra parameter for the callback to deal with this case. 