### PR TITLE
Humidifier/HeaterB

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ npm install wemo-client
 var Wemo = require('wemo-client');
 var wemo = new Wemo();
 
-wemo.discover(function(deviceInfo) {
+wemo.discover(function(err, deviceInfo) {
   console.log('Wemo Device Found: %j', deviceInfo);
 
   // Get the client for the found device
@@ -148,7 +148,7 @@ Capability of a device connected via Wemo Bridge changed its status.
 
 #### Event: attributeList (name, value, prevalue, timestamp)
 
-Attribute of a device has changed. This seems to apply to Wemo Maker only for now.
+Attribute of a device has changed. This applies to Wemo Maker, Wemo Humidifier, and Wemo Heater (may not be exhaustive).
 
 * **String** *name* Name of the attribute, e.g. `Switch`
 * **String** *value* Current value
@@ -257,6 +257,26 @@ Get power consumption data for a Wemo Insight Switch
 * **Callback** *cb* cb(err, binaryState, instantPower, data)
 
 The callback is passed the `binaryState`, `instantPower` and `data` (see [Event: InsightParams](#event-insightparams-binarystate-instantpower-data))
+
+#### setAttributes(attributes, cb)
+
+Sets attributes on a device (Heater, Humidifier), used for setting FanMode, Mode, TimeRemaining, and SetTemperature (not exhaustive) to a value.
+
+* **OBJECT** *attributes* 
+```javascript
+{
+  "SetTemperature": "73.0",
+  "TimeRemaining": "120"
+}
+```
+
+You can set any number of attributes in this manner, and if you do not specify an attribute, it is left unchanged on the device.
+
+* **Callback** *cb* cb(err, returnValue)
+
+The callback is passed the `returnValue`, which is what the device returned for that SOAP call.
+
+
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ The callback is passed the `binaryState`, `instantPower` and `data` (see [Event:
 
 Sets attributes on a device (Heater, Humidifier), used for setting FanMode, Mode, TimeRemaining, and SetTemperature (not exhaustive) to a value.
 
-* **OBJECT** *attributes* 
+* **Object** *attributes* 
 ```javascript
 {
   "SetTemperature": "73.0",

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Low-level client library for controlling recent Wemo devices including Bulbs. Su
   * Wemo Motion
   * Wemo Insight Switch
   * Wemo Maker
+  * Wemo Humidifier
+  * Wemo Heater
   * Wemo Link
     * Wemo LED Bulb
     * OSRAM Lightify Flex RGBW
@@ -84,6 +86,8 @@ Static map of supported models and device types.
 * Maker
 * Insight
 * LightSwitch
+* Humidifier
+* HeaterB
 
 #### discover(cb)
 

--- a/client.js
+++ b/client.js
@@ -231,6 +231,22 @@ WemoClient.prototype.getBinaryState = function(cb) {
   });
 };
 
+WemoClient.prototype.setAttributes = function(attributes, cb) {
+  var builder = new xml2js.Builder({ rootName: 'attribute', headless: true, renderOpts: { pretty: false } });
+
+  var xml_attributes = Object.keys(attributes).map(function(attribute_key) {
+    return builder.buildObject({ name: attribute_key, value: attributes[attribute_key]});
+  }).join('');
+
+  var xml = xml_attributes;
+
+  this.soapAction('urn:Belkin:service:deviceevent:1', 'SetAttributes', {
+    attributeList: {
+      '#text': xml
+    }
+  }, cb);
+};
+
 WemoClient.prototype.getAttributes = function(cb) {
   this.soapAction('urn:Belkin:service:deviceevent:1', 'GetAttributes', null, function(err, data) {
     if (err) return cb(err);

--- a/client.js
+++ b/client.js
@@ -235,7 +235,7 @@ WemoClient.prototype.setAttributes = function(attributes, cb) {
   var builder = new xml2js.Builder({ rootName: 'attribute', headless: true, renderOpts: { pretty: false } });
 
   var xml_attributes = Object.keys(attributes).map(function(attribute_key) {
-    return builder.buildObject({ name: attribute_key, value: attributes[attribute_key]});
+    return builder.buildObject({ name: attribute_key, value: attributes[attribute_key] });
   }).join('');
 
   var xml = xml_attributes;

--- a/client.js
+++ b/client.js
@@ -238,11 +238,9 @@ WemoClient.prototype.setAttributes = function(attributes, cb) {
     return builder.buildObject({ name: attribute_key, value: attributes[attribute_key] });
   }).join('');
 
-  var xml = xml_attributes;
-
   this.soapAction('urn:Belkin:service:deviceevent:1', 'SetAttributes', {
     attributeList: {
-      '#text': xml
+      '#text': xml_attributes
     }
   }, cb);
 };

--- a/examples/bulb.js
+++ b/examples/bulb.js
@@ -10,7 +10,7 @@ function dimBulb(client, device) {
   }, 3000);
 }
 
-function foundDevice(deviceInfo) {
+function foundDevice(err, deviceInfo) {
   if (deviceInfo.deviceType === Wemo.DEVICE_TYPE.Bridge) {
     console.log('Wemo Bridge found: %s', deviceInfo.friendlyName);
 

--- a/examples/heater.js
+++ b/examples/heater.js
@@ -1,0 +1,33 @@
+var Wemo = require('../index');
+var wemo = new Wemo();
+
+function foundDevice(err, deviceInfo) {
+  if (deviceInfo.deviceType === Wemo.DEVICE_TYPE.HeaterB) {
+    console.log('Wemo HeaterB found: %s', deviceInfo.friendlyName);
+
+    // Get the client for the found device
+    var client = wemo.client(deviceInfo);
+
+    client.getAttributes(function(err, attributes) {
+      console.log("Attributes for heater: ", attributes);
+    });
+
+    /*
+    client.setAttributes({ "SetTemperature": "72.0", "TimeRemaining": "120" }, function(err, retval) {
+      console.log("Look I just set the temperature to 72.0 using NodeJS");
+    });
+    */
+    // Handle attributeList events
+    client.on('attributeList', function(key, value) {
+      console.log(key, " has changed to ", value);
+    });
+  }
+}
+
+// Inital discovery
+wemo.discover(foundDevice);
+
+// Repeat discovery as some devices may appear late
+setInterval(function() {
+  wemo.discover(foundDevice);
+}, 15000);

--- a/examples/humidifier.js
+++ b/examples/humidifier.js
@@ -1,0 +1,28 @@
+var Wemo = require('../index');
+var wemo = new Wemo();
+
+function foundDevice(err, deviceInfo) {
+  if (deviceInfo.deviceType === Wemo.DEVICE_TYPE.Humidifier) {
+    console.log('Wemo Humidifier found: %s', deviceInfo.friendlyName);
+
+    // Get the client for the found device
+    var client = wemo.client(deviceInfo);
+
+    client.getAttributes(function(err, attributes) {
+      console.log("Attributes for humidifier: ", attributes);
+    });
+
+    // Handle attributeList events
+    client.on('attributeList', function(key, value) {
+      console.log(key, " has changed to ", value);
+    });
+  }
+}
+
+// Inital discovery
+wemo.discover(foundDevice);
+
+// Repeat discovery as some devices may appear late
+setInterval(function() {
+  wemo.discover(foundDevice);
+}, 15000);

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,7 +1,7 @@
 var Wemo = require('../index');
 var wemo = new Wemo();
 
-function foundDevice(deviceInfo) {
+function foundDevice(err, deviceInfo) {
   console.log('Wemo Device Found: %s (%s)',
     deviceInfo.friendlyName, deviceInfo.deviceType);
 

--- a/examples/insight.js
+++ b/examples/insight.js
@@ -1,7 +1,7 @@
 var Wemo = require('../index');
 var wemo = new Wemo();
 
-function foundDevice(device) {
+function foundDevice(err, device) {
   if (device.deviceType === Wemo.DEVICE_TYPE.Insight) {
     console.log('Wemo Insight Switch found: %s', device.friendlyName);
 

--- a/examples/lightswitch.js
+++ b/examples/lightswitch.js
@@ -1,7 +1,7 @@
 var Wemo = require('../index');
 var wemo = new Wemo();
 
-function foundDevice(device) {
+function foundDevice(err, device) {
   if (device.deviceType === Wemo.DEVICE_TYPE.LightSwitch) {
     console.log('Wemo Light Switch found: %s', device.friendlyName);
 

--- a/examples/maker.js
+++ b/examples/maker.js
@@ -1,7 +1,7 @@
 var Wemo = require('../index');
 var wemo = new Wemo();
 
-function foundDevice(device) {
+function foundDevice(err, device) {
   if (device.deviceType === Wemo.DEVICE_TYPE.Maker) {
     console.log('Wemo Maker found: %s', device.friendlyName);
 

--- a/examples/motion.js
+++ b/examples/motion.js
@@ -1,7 +1,7 @@
 var Wemo = require('../index');
 var wemo = new Wemo();
 
-function foundDevice(device) {
+function foundDevice(err, device) {
   if (device.deviceType === Wemo.DEVICE_TYPE.Motion) {
     console.log('Wemo Motion found: %s', device.friendlyName);
 

--- a/examples/switch.js
+++ b/examples/switch.js
@@ -1,7 +1,7 @@
 var Wemo = require('../index');
 var wemo = new Wemo();
 
-function foundDevice(device) {
+function foundDevice(err, device) {
   if (device.deviceType === Wemo.DEVICE_TYPE.Switch) {
     console.log('Wemo Switch found: %s', device.friendlyName);
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,9 @@ Wemo.DEVICE_TYPE = {
   Motion: 'urn:Belkin:device:sensor:1',
   Maker: 'urn:Belkin:device:Maker:1',
   Insight: 'urn:Belkin:device:insight:1',
-  LightSwitch: 'urn:Belkin:device:lightswitch:1'
+  LightSwitch: 'urn:Belkin:device:lightswitch:1',
+  Humidifier: 'urn:Belkin:device:Humidifier:1',
+  HeaterB: 'urn:Belkin:device:HeaterB:1'
 };
 
 Wemo.prototype.load = function(setupUrl, cb) {


### PR DESCRIPTION
This utilizing the existing attributeList event for tracking how the Humidifier/HeaterB, and adds a SetAttributes call, which allows you to switch modes, set remaining timers, and desired humidity/temp.

Additionally I noticed the examples were not working, and found it was due to an 'err' being passed as the first arg to the foundDevice callback.

Added examples of the Humidifier/HeaterB.


(I additionally have a WeMo crockpot that I figured out how it works, but need to implement it in your library)