### PR TITLE
Adding Basic Dimmer Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Low-level client library for controlling recent Wemo devices including Bulbs. Su
     * OSRAM Lightify Tunable White (untested)
     * OSRAM Gardenspot Mini RGB (untested)
   * Wemo Light Switch
-
+  * Wemo Dimmer
+  
 ## Install
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ Wemo.DEVICE_TYPE = {
   Maker: 'urn:Belkin:device:Maker:1',
   Insight: 'urn:Belkin:device:insight:1',
   LightSwitch: 'urn:Belkin:device:lightswitch:1',
+  Dimmer: 'urn:Belkin:device:dimmer:1',
   Humidifier: 'urn:Belkin:device:Humidifier:1',
   HeaterB: 'urn:Belkin:device:HeaterB:1'
 };

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ Wemo.DEVICE_TYPE = {
   Maker: 'urn:Belkin:device:Maker:1',
   Insight: 'urn:Belkin:device:insight:1',
   LightSwitch: 'urn:Belkin:device:lightswitch:1',
-  // Dimmer: 'urn:Belkin:device:dimmer:1',
+  Dimmer: 'urn:Belkin:device:dimmer:1',
   Humidifier: 'urn:Belkin:device:Humidifier:1',
   HeaterB: 'urn:Belkin:device:HeaterB:1'
 };

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ Wemo.DEVICE_TYPE = {
   Maker: 'urn:Belkin:device:Maker:1',
   Insight: 'urn:Belkin:device:insight:1',
   LightSwitch: 'urn:Belkin:device:lightswitch:1',
-  Dimmer: 'urn:Belkin:device:dimmer:1',
+  // Dimmer: 'urn:Belkin:device:dimmer:1',
   Humidifier: 'urn:Belkin:device:Humidifier:1',
   HeaterB: 'urn:Belkin:device:HeaterB:1'
 };


### PR DESCRIPTION
Simply added the dimmer type to the DEVICE_TYPE list, this enables homebridge-platform-wemo to use it as a switch.