### PR TITLE
Add support for supplying content length in requests

### DIFF
--- a/client.js
+++ b/client.js
@@ -16,7 +16,7 @@ function mapCapabilities(capabilityIds, capabilityValues) {
   return result;
 }
 
-var WemoClient = module.exports = function(config) {
+var WemoClient = module.exports = function(config, options) {
   EventEmitter.call(this);
   this.host = config.host;
   this.port = config.port;
@@ -26,6 +26,9 @@ var WemoClient = module.exports = function(config) {
   this.callbackURL = config.callbackURL;
   this.device = config;
   this.error = undefined;
+  if (options) {
+    this.defineRequestBodyLength = options.defineRequestBodyLength;
+  }
 
   // Create map of services
   config.serviceList.service.forEach(function(service) {
@@ -112,6 +115,10 @@ WemoClient.prototype.soapAction = function(serviceType, action, body, cb) {
       'Content-Type': 'text/xml; charset="utf-8"'
     }
   };
+
+  if (this.defineRequestBodyLength) {
+    options.headers['CONTENT-LENGTH'] = payload.length;
+  }
 
   WemoClient.request(options, payload, function(err, response) {
     if (err) {

--- a/index.js
+++ b/index.js
@@ -145,11 +145,11 @@ Wemo.prototype.getCallbackURL = function(opts) {
   return this._callbackURL;
 };
 
-Wemo.prototype.client = function(device) {
+Wemo.prototype.client = function(device, options) {
   if (this._clients[device.UDN] && !this._clients[device.UDN].error) {
     return this._clients[device.UDN];
   }
 
-  var client = this._clients[device.UDN] = new WemoClient(device);
+  var client = this._clients[device.UDN] = new WemoClient(device, options);
   return client;
 };


### PR DESCRIPTION
This enables support for servers which do not support use of chunked transfer encoding in requests, e.g. emulated devices.