### PR TITLE
added patch for new switches using rtos

### DIFF
--- a/client.js
+++ b/client.js
@@ -74,7 +74,8 @@ class WemoClient extends EventEmitter {
       method: 'POST',
       headers: {
         SOAPACTION: '"' + serviceType + '#' + action + '"',
-        'Content-Type': 'text/xml; charset="utf-8"'
+        'Content-Type': 'text/xml; charset="utf-8"',
+        'Content-Length': payload.length
       }
     }
 


### PR DESCRIPTION
I had an issue getting the library to work with a new dimmer switch. The only difference I could see in the returned setup.xml was that the new device used a new firmware (WEMO_WW_2.00.20110904.PVT-RTOS-DimmerV2), and also had the tag <rtos>1</rtos>. The failure behavior was getting an ECONNRESET whenever interacting with the device. The only necessary change turned out to be adding the content length header, as I have done in the proposed change.